### PR TITLE
Make results of BuiltInSearch consistent

### DIFF
--- a/src/SearchAlgorithms.Core/Algorithms/BuiltInSearch.cs
+++ b/src/SearchAlgorithms.Core/Algorithms/BuiltInSearch.cs
@@ -13,7 +13,27 @@ namespace SearchAlgorithms.Core.Algorithms
 
         public List<int> Search(in string lookingString, in string longString)
         {
-            return Regex.Matches(longString, lookingString).Cast<Match>().Select(m => m.Index).ToList();
+            List<int> result = new List<int>();
+            for (int i = 0; i < longString.Length; i++)
+            {
+                if (i + lookingString.Length - 1 < longString.Length && lookingString[0] == longString[i])
+                {
+                    bool isFound = true;
+                    for (int j = 1; j < lookingString.Length; j++)
+                    {
+                        if (lookingString[j] != longString[i + j])
+                        {
+                            isFound = false;
+                            break;
+                        }
+                    }
+                    if (isFound)
+                    {
+                        result.Add(i);
+                    }
+                }
+            }
+            return result;
         }
     }
 }

--- a/src/SearchAlgorithms.Core/Algorithms/TestSearch.cs
+++ b/src/SearchAlgorithms.Core/Algorithms/TestSearch.cs
@@ -16,31 +16,11 @@ namespace SearchAlgorithms.Core.Algorithms
         {
             return "random-time testing algorithm";
         }
-        public List<int> Search(in string lookingString,in string longString)
+        public List<int> Search(in string lookingString, in string longString)
         {
 
             Thread.Sleep(random%100+1);
-            List<int> result = new List<int>();
-            for (int i = 0; i < longString.Length; i++)
-            {
-                if (i + lookingString.Length - 1 < longString.Length && lookingString[0] == longString[i] )
-                {
-                    bool isFound = true;
-                    for (int j = 1; j < lookingString.Length; j++)
-                    {
-                        if (lookingString[j] != longString[i + j])
-                        {
-                            isFound = false;
-                            break;
-                        }
-                    }
-                    if (isFound)
-                    {
-                        result.Add(i);
-                    }
-                }
-            }
-            return result;
+            return new BuiltInSearch().Search(lookingString, longString);
         }
 
     }

--- a/src/SearchAlgorithms.Core/Program.cs
+++ b/src/SearchAlgorithms.Core/Program.cs
@@ -11,11 +11,11 @@ namespace SearchAlgorithms.Core
     {
         static void Main(string[] args)
         {
-            var currentlyCheckedAlgorithm = new BinarySearch();
+            var currentlyCheckedAlgorithm = new KMPSearch();
             var correctlyWorkingAlgorithm = new BuiltInSearch();
 
-            string haystack = GetRandomString(1000).SortCharacters();
-            string needle = haystack[new Random().Next(0, haystack.Length - 1)].ToString().SortCharacters();
+            string haystack = "aaaooooooaa";
+            string needle = "ooo";
 
             Console.WriteLine(haystack);
             Console.WriteLine(needle);


### PR DESCRIPTION
When trying to find the string "oo" inside the string "oooo", all other algorithms returned [0, 1, 2] while BuiltInSearch returned [0, 2]. This behavior has been changed: from now on, BuiltInSearch will also return [0, 1, 2].